### PR TITLE
Disambiguate Math Function in ChartUtils

### DIFF
--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -80,9 +80,9 @@ extension Double
             self != 0
             else { return self }
 
-        let d = ceil(log10(self < 0 ? -self : self))
+        let d = ceil(Foundation.log10(self < 0 ? -self : self))
         let pw = 1 - Int(d)
-        let magnitude = pow(10.0, Double(pw))
+        let magnitude = Foundation.pow(10.0, Double(pw))
         let shifted = (self * magnitude).rounded()
         return shifted / magnitude
     }
@@ -102,7 +102,7 @@ extension Double
             !i.isNaN
             else { return 0 }
 
-        return Int(ceil(-log10(i))) + 2
+        return Int(ceil(-Foundation.log10(i))) + 2
     }
 }
 


### PR DESCRIPTION
There seems to be an issue with Swift Algorithms making the compiler not be able to resolve `log10` and `pow`. Prefixing those calls with `Foundation.` seemed to fix the issue